### PR TITLE
Add Cloudflare Worker backend and Turnstile-enabled forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,128 @@
 # HaloHub Website
 
-A single-page launch site for **HaloHub**, a community platform that circulates physical, enriching resources so children can flourish beyond the screen.
+A single-page launch site for **HaloHub**, a community platform that circulates physical, enriching resources so children can flourish beyond the screen. The project now ships with a Cloudflare Worker backend that validates pilot sign-up submissions, verifies Cloudflare Turnstile tokens, and persists data to a D1 database.
 
 ## Getting started
 
-Open `index.html` in your browser to explore the experience. The page is fully static and styled with `styles.css`; interactive touches (button state + dynamic year) live in `script.js`.
+Open `index.html` in your browser to explore the experience. The page is fully static and styled with `styles.css`; interactive touches (dynamic year, form submission flow, Turnstile integration) live in `script.js`.
+
+### Front-end configuration
+
+The page reads two data attributes from the `<body>` element:
+
+- `data-worker-endpoint` – the fully qualified URL for your deployed Worker endpoint (for example, `https://halo-hub-submissions.your-account.workers.dev/submissions`).
+- `data-turnstile-sitekey` – the Turnstile site key created in the Cloudflare dashboard.
+
+Update those values after you provision the Worker and Turnstile site.
 
 ## Structure
 
-- `index.html` – landing page markup with mission, product story, and pilot sign-up forms for families, donors, and collaborators.
-- `styles.css` – global design language featuring gradients, glassmorphism, and responsive layouts.
-- `script.js` – lightweight enhancements for form confirmation and footer year.
+- `index.html` – landing page markup with mission, product story, pilot sign-up forms, and Turnstile widgets.
+- `styles.css` – global design language featuring gradients, glassmorphism, responsive layouts, and form state styles.
+- `script.js` – form submission logic that renders Turnstile, validates client-side configuration, and sends JSON payloads to the Worker.
+- `worker/` – Cloudflare Worker source (TypeScript), Wrangler configuration, and helper files.
+- `migrations/` – SQL migrations for the D1 database schema.
 
-Feel free to adapt the content, integrate with your preferred framework, or connect the forms to a backend or marketing automation platform.
+## Cloudflare Turnstile setup
+
+1. Sign in to the [Cloudflare dashboard](https://dash.cloudflare.com/).
+2. Navigate to **Turnstile** → **Add site**.
+3. Choose a descriptive name, select the widget type (managed recommended), and add your domains (`https://tymai-dev.github.io` and `https://halohub.com`).
+4. Copy the generated **Site Key** and **Secret Key**.
+5. Update `index.html` so that `data-turnstile-sitekey` equals your site key.
+6. Store the secret key in the Worker with Wrangler:
+
+   ```bash
+   cd worker
+   npx wrangler secret put TURNSTILE_SECRET
+   ```
+
+## Worker configuration and deployment
+
+The Worker code lives in `worker/src/index.ts`. Wrangler reads configuration from `worker/wrangler.toml`.
+
+### D1 schema
+
+The D1 tables for the three pilot forms are defined in `migrations/0001_create_tables.sql`:
+
+```sql
+-- D1 schema for HaloHub pilot submissions
+CREATE TABLE IF NOT EXISTS families (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  region TEXT NOT NULL,
+  interest TEXT,
+  submitted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS donors (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  focus TEXT,
+  message TEXT,
+  submitted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS collaborators (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  expertise TEXT,
+  idea TEXT,
+  submitted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_families_email ON families(email);
+CREATE INDEX IF NOT EXISTS idx_donors_email ON donors(email);
+CREATE INDEX IF NOT EXISTS idx_collaborators_email ON collaborators(email);
+```
+
+### Create the D1 database binding
+
+1. Provision a D1 database in the Cloudflare dashboard (Workers &amp; Pages → D1 → Create Database).
+2. Copy the database ID and replace `REPLACE_WITH_D1_DATABASE_ID` in `worker/wrangler.toml`.
+3. Optional: adjust `ALLOWED_ORIGINS` in `worker/wrangler.toml` to include additional domains separated by commas.
+
+### Run migrations with Wrangler
+
+From the `worker/` directory:
+
+```bash
+cd worker
+npx wrangler d1 execute halo_hub_submissions --file=../migrations/0001_create_tables.sql
+```
+
+Replace `halo_hub_submissions` with the database name you chose if it differs.
+
+### Deploy the Worker
+
+```bash
+cd worker
+npx wrangler deploy
+```
+
+Wrangler will bundle the TypeScript Worker, upload it to Cloudflare, and print the deployed URL. Copy that URL into the `data-worker-endpoint` attribute in `index.html`.
+
+### View submissions from D1
+
+Use Wrangler to inspect your records (again from `worker/`):
+
+```bash
+npx wrangler d1 execute halo_hub_submissions --command "SELECT * FROM families ORDER BY submitted_at DESC LIMIT 25;"
+npx wrangler d1 execute halo_hub_submissions --command "SELECT * FROM donors ORDER BY submitted_at DESC LIMIT 25;"
+npx wrangler d1 execute halo_hub_submissions --command "SELECT * FROM collaborators ORDER BY submitted_at DESC LIMIT 25;"
+```
+
+Adjust the `SELECT` statements to filter or paginate as needed.
+
+## What the Worker does
+
+- Accepts JSON `POST` requests containing `formType`, `data`, and a `cf-turnstile-response` field (alias `turnstileToken` supported).
+- Rejects requests that fail schema validation, Turnstile verification, or originate from outside the allowed domains.
+- Writes valid submissions into the corresponding D1 table.
+- Responds with `{"ok": true}` on success or a descriptive error message on failure.
+- Supports CORS (restricted to `https://tymai-dev.github.io` and `https://halohub.com`) and handles `OPTIONS` preflight requests.
+
+Once the Worker is deployed and the front-end attributes are updated, visitors can complete the Turnstile challenge, submit the form, and receive immediate confirmation without leaving the page.

--- a/index.html
+++ b/index.html
@@ -11,8 +11,16 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
+    <script
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+      async
+      defer
+    ></script>
   </head>
-  <body>
+  <body
+    data-worker-endpoint="https://your-worker-subdomain.workers.dev/submissions"
+    data-turnstile-sitekey="0x0000000000000000000000000000000AA"
+  >
     <header class="site-header">
       <div class="container nav">
         <a class="logo" href="#top" aria-label="HaloHub home">
@@ -180,7 +188,7 @@
             </p>
           </div>
           <div class="pilot-forms">
-            <form class="pilot-form" aria-labelledby="family-title">
+            <form class="pilot-form" aria-labelledby="family-title" data-form-type="family">
               <h3 id="family-title">Families &amp; Caregivers</h3>
               <p>Request early access to resource libraries in your community.</p>
               <label for="family-name">Name</label>
@@ -195,10 +203,13 @@
               <label for="family-interest">What resources spark your child’s curiosity?</label>
               <textarea id="family-interest" name="family-interest" rows="3"></textarea>
 
+              <div class="turnstile-container" data-turnstile></div>
+
               <button type="submit" class="btn primary full">Apply as a family</button>
+              <p class="form-feedback" role="status" aria-live="polite"></p>
             </form>
 
-            <form class="pilot-form" aria-labelledby="donor-title">
+            <form class="pilot-form" aria-labelledby="donor-title" data-form-type="donor">
               <h3 id="donor-title">Donors &amp; Funders</h3>
               <p>Champion regenerative resource hubs for kids in your city.</p>
               <label for="donor-name">Name / Organization</label>
@@ -213,10 +224,13 @@
               <label for="donor-message">How would you like to contribute?</label>
               <textarea id="donor-message" name="donor-message" rows="3"></textarea>
 
+              <div class="turnstile-container" data-turnstile></div>
+
               <button type="submit" class="btn primary full">Partner as a donor</button>
+              <p class="form-feedback" role="status" aria-live="polite"></p>
             </form>
 
-            <form class="pilot-form" aria-labelledby="collab-title">
+            <form class="pilot-form" aria-labelledby="collab-title" data-form-type="collaborator">
               <h3 id="collab-title">Collaborators &amp; Builders</h3>
               <p>Let’s design programming, tech, and experiences together.</p>
               <label for="collab-name">Name / Organization</label>
@@ -231,7 +245,10 @@
               <label for="collab-idea">What would you like to build?</label>
               <textarea id="collab-idea" name="collab-idea" rows="3"></textarea>
 
+              <div class="turnstile-container" data-turnstile></div>
+
               <button type="submit" class="btn primary full">Collaborate with HaloHub</button>
+              <p class="form-feedback" role="status" aria-live="polite"></p>
             </form>
           </div>
         </div>

--- a/migrations/0001_create_tables.sql
+++ b/migrations/0001_create_tables.sql
@@ -1,0 +1,31 @@
+-- D1 schema for HaloHub pilot submissions
+CREATE TABLE IF NOT EXISTS families (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  region TEXT NOT NULL,
+  interest TEXT,
+  submitted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS donors (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  focus TEXT,
+  message TEXT,
+  submitted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS collaborators (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL,
+  expertise TEXT,
+  idea TEXT,
+  submitted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_families_email ON families(email);
+CREATE INDEX IF NOT EXISTS idx_donors_email ON donors(email);
+CREATE INDEX IF NOT EXISTS idx_collaborators_email ON collaborators(email);

--- a/script.js
+++ b/script.js
@@ -1,21 +1,191 @@
 const yearSpan = document.getElementById('year');
 if (yearSpan) {
-  yearSpan.textContent = new Date().getFullYear();
+  yearSpan.textContent = new Date().getFullYear().toString();
 }
 
-const forms = document.querySelectorAll('.pilot-form');
-forms.forEach((form) => {
-  form.addEventListener('submit', (event) => {
-    event.preventDefault();
-    const button = form.querySelector('button[type="submit"]');
-    if (button) {
-      const original = button.textContent;
-      button.textContent = 'Thanks! We’ll be in touch soon.';
-      button.disabled = true;
-      setTimeout(() => {
-        button.textContent = original;
-        button.disabled = false;
-      }, 3000);
+const WORKER_ENDPOINT = document.body?.dataset.workerEndpoint?.trim() ?? '';
+const TURNSTILE_SITE_KEY = document.body?.dataset.turnstileSitekey?.trim() ?? '';
+
+const formFieldMap = {
+  family: {
+    name: 'family-name',
+    email: 'family-email',
+    region: 'family-region',
+    interest: 'family-interest',
+  },
+  donor: {
+    name: 'donor-name',
+    email: 'donor-email',
+    focus: 'donor-focus',
+    message: 'donor-message',
+  },
+  collaborator: {
+    name: 'collab-name',
+    email: 'collab-email',
+    expertise: 'collab-expertise',
+    idea: 'collab-idea',
+  },
+};
+
+const widgetIds = new Map();
+const submitLabels = new Map();
+
+function findFeedbackElement(form) {
+  return form.querySelector('.form-feedback');
+}
+
+function setFeedback(form, message, type) {
+  const feedback = findFeedbackElement(form);
+  if (!feedback) return;
+  feedback.textContent = message;
+  feedback.classList.remove('form-feedback--success', 'form-feedback--error');
+  if (type) {
+    feedback.classList.add(type === 'success' ? 'form-feedback--success' : 'form-feedback--error');
+  }
+}
+
+function toggleSubmittingState(form, submitting) {
+  const button = form.querySelector('button[type="submit"]');
+  if (!button) {
+    return;
+  }
+  if (!submitLabels.has(button)) {
+    submitLabels.set(button, button.textContent ?? 'Submit');
+  }
+  button.disabled = submitting;
+  button.textContent = submitting ? 'Submitting…' : submitLabels.get(button);
+}
+
+function collectFormValues(form, formType) {
+  const fieldMap = formFieldMap[formType];
+  const data = {};
+  Object.entries(fieldMap).forEach(([key, name]) => {
+    const value = form.elements.namedItem(name);
+    if (value && 'value' in value) {
+      data[key] = value.value.trim();
+    } else {
+      data[key] = '';
     }
   });
+  return data;
+}
+
+function resetTurnstile(form) {
+  const widgetId = widgetIds.get(form);
+  if (widgetId && typeof window !== 'undefined' && window.turnstile) {
+    window.turnstile.reset(widgetId);
+  }
+}
+
+function ensureTurnstile() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const attemptRender = () => {
+    if (!window.turnstile) {
+      window.setTimeout(attemptRender, 200);
+      return;
+    }
+
+    window.turnstile.ready(() => {
+      document.querySelectorAll('.pilot-form').forEach((form) => {
+        if (!(form instanceof HTMLFormElement) || widgetIds.has(form)) {
+          return;
+        }
+        const container = form.querySelector('.turnstile-container');
+        if (!(container instanceof HTMLElement)) {
+          return;
+        }
+        const widgetId = window.turnstile.render(container, {
+          sitekey: TURNSTILE_SITE_KEY,
+          callback: () => {
+            setFeedback(form, '', null);
+          },
+          'expired-callback': () => {
+            setFeedback(form, 'Please complete the verification again.', 'error');
+          },
+          'error-callback': () => {
+            setFeedback(form, 'Verification is unavailable. Please refresh and try again.', 'error');
+          },
+        });
+        widgetIds.set(form, widgetId);
+      });
+    });
+  };
+
+  attemptRender();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const forms = document.querySelectorAll('.pilot-form');
+  forms.forEach((form) => {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+
+      const formType = form.dataset.formType;
+      if (!formType || !(formType in formFieldMap)) {
+        setFeedback(form, 'Unsupported form type.', 'error');
+        return;
+      }
+
+      if (!WORKER_ENDPOINT || WORKER_ENDPOINT.includes('your-worker-subdomain')) {
+        setFeedback(form, 'Form submission is not configured yet. Please update the worker endpoint.', 'error');
+        return;
+      }
+
+      if (!TURNSTILE_SITE_KEY || TURNSTILE_SITE_KEY.startsWith('0x000000')) {
+        setFeedback(form, 'Turnstile is not configured. Please supply your site key.', 'error');
+        return;
+      }
+
+      const widgetId = widgetIds.get(form);
+      if (!widgetId || typeof window === 'undefined' || !window.turnstile) {
+        setFeedback(form, 'Verification could not be loaded. Please refresh the page.', 'error');
+        return;
+      }
+
+      const token = window.turnstile.getResponse(widgetId);
+      if (!token) {
+        setFeedback(form, 'Please complete the verification challenge.', 'error');
+        return;
+      }
+
+      const payload = {
+        formType,
+        data: collectFormValues(form, formType),
+        'cf-turnstile-response': token,
+      };
+
+      toggleSubmittingState(form, true);
+      setFeedback(form, 'Submitting your details…', null);
+
+      try {
+        const response = await fetch(WORKER_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        const result = await response.json().catch(() => ({}));
+
+        if (response.ok && result && result.ok) {
+          setFeedback(form, 'Thanks! We’ll be in touch soon.', 'success');
+          form.reset();
+        } else {
+          const errorMessage = result?.error || 'We could not submit your request. Please try again.';
+          setFeedback(form, errorMessage, 'error');
+        }
+      } catch (error) {
+        setFeedback(form, 'Network error. Please try again in a moment.', 'error');
+      } finally {
+        toggleSubmittingState(form, false);
+        resetTurnstile(form);
+      }
+    });
+  });
+
+  if (TURNSTILE_SITE_KEY && !TURNSTILE_SITE_KEY.startsWith('0x000000')) {
+    ensureTurnstile();
+  }
 });

--- a/styles.css
+++ b/styles.css
@@ -427,6 +427,25 @@ img {
   box-shadow: 0 0 0 3px rgba(91, 61, 245, 0.18);
 }
 
+.turnstile-container {
+  margin-top: 0.75rem;
+}
+
+.form-feedback {
+  min-height: 1.2rem;
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.form-feedback--success {
+  color: #1f8a4d;
+}
+
+.form-feedback--error {
+  color: #d23f52;
+}
+
 .site-footer {
   background: #120a24;
   color: rgba(255, 255, 255, 0.86);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,424 @@
+interface D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement;
+  run<T = unknown>(): Promise<T>;
+}
+
+interface D1Database {
+  prepare(query: string): D1PreparedStatement;
+}
+
+interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+  passThroughOnException(): void;
+}
+
+type ExportedHandler<Env = unknown> = {
+  fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> | Response;
+};
+
+export interface Env {
+  DB: D1Database;
+  TURNSTILE_SECRET: string;
+  ALLOWED_ORIGINS?: string;
+}
+
+type FormType = 'family' | 'donor' | 'collaborator';
+
+type SubmissionResult =
+  | { success: true; table: string; parameters: unknown[] }
+  | { success: false; error: string };
+
+type FamilySubmission = {
+  name: string;
+  email: string;
+  region: string;
+  interest: string | null;
+};
+
+type DonorSubmission = {
+  name: string;
+  email: string;
+  focus: string | null;
+  message: string | null;
+};
+
+type CollaboratorSubmission = {
+  name: string;
+  email: string;
+  expertise: string | null;
+  idea: string | null;
+};
+
+const DEFAULT_ALLOWED_ORIGINS = ['https://tymai-dev.github.io', 'https://halohub.com'];
+
+const baseCorsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Methods': 'POST,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Max-Age': '86400',
+  Vary: 'Origin',
+};
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default {
+  async fetch(request, env): Promise<Response> {
+    const origin = request.headers.get('Origin');
+    const allowedOrigins = getAllowedOrigins(env.ALLOWED_ORIGINS);
+
+    if (request.method === 'OPTIONS') {
+      const corsHeaders = createCorsHeaders(origin, allowedOrigins);
+      if (!corsHeaders) {
+        return new Response(null, { status: 403, headers: baseErrorHeaders() });
+      }
+      return new Response(null, { status: 204, headers: corsHeaders });
+    }
+
+    if (request.method !== 'POST') {
+      return jsonResponse(
+        { ok: false, error: 'Method not allowed. Use POST.' },
+        405,
+        mergeHeaders(baseErrorHeaders(), createCorsHeaders(origin, allowedOrigins)),
+      );
+    }
+
+    const corsHeaders = createCorsHeaders(origin, allowedOrigins);
+    if (origin && !corsHeaders) {
+      return jsonResponse(
+        { ok: false, error: 'Origin not allowed.' },
+        403,
+        mergeHeaders(baseErrorHeaders(), baseCorsHeaders),
+      );
+    }
+
+    const contentType = request.headers.get('Content-Type') || '';
+    if (!contentType.toLowerCase().includes('application/json')) {
+      return jsonResponse(
+        { ok: false, error: 'Content-Type must be application/json.' },
+        400,
+        mergeHeaders(baseErrorHeaders(), corsHeaders),
+      );
+    }
+
+    let payload: unknown;
+    try {
+      payload = await request.json();
+    } catch (error) {
+      return jsonResponse(
+        { ok: false, error: 'Invalid JSON payload.' },
+        400,
+        mergeHeaders(baseErrorHeaders(), corsHeaders),
+      );
+    }
+
+    if (!isSubmissionPayload(payload)) {
+      return jsonResponse(
+        { ok: false, error: 'Missing or invalid submission payload.' },
+        400,
+        mergeHeaders(baseErrorHeaders(), corsHeaders),
+      );
+    }
+
+    const { formType, data } = payload;
+    const token = extractTurnstileToken(payload);
+
+    if (!token) {
+      return jsonResponse(
+        { ok: false, error: 'Turnstile token is required.' },
+        400,
+        mergeHeaders(baseErrorHeaders(), corsHeaders),
+      );
+    }
+
+    const verification = await verifyTurnstileToken(token, env.TURNSTILE_SECRET, request);
+    if (!verification.success) {
+      return jsonResponse(
+        { ok: false, error: verification.error },
+        400,
+        mergeHeaders(baseErrorHeaders(), corsHeaders),
+      );
+    }
+
+    const submissionResult = validateSubmission(formType, data);
+    if (!submissionResult.success) {
+      return jsonResponse(
+        { ok: false, error: submissionResult.error },
+        400,
+        mergeHeaders(baseErrorHeaders(), corsHeaders),
+      );
+    }
+
+    try {
+      await env.DB.prepare(getInsertStatement(submissionResult.table))
+        .bind(...submissionResult.parameters)
+        .run();
+    } catch (error) {
+      return jsonResponse(
+        { ok: false, error: 'Unable to record submission.' },
+        500,
+        mergeHeaders(baseErrorHeaders(), corsHeaders),
+      );
+    }
+
+    return jsonResponse({ ok: true }, 200, mergeHeaders(baseSuccessHeaders(), corsHeaders));
+  },
+} satisfies ExportedHandler<Env>;
+
+function getAllowedOrigins(value?: string): string[] {
+  if (!value) {
+    return DEFAULT_ALLOWED_ORIGINS;
+  }
+
+  return value
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+function createCorsHeaders(origin: string | null, allowed: string[]): HeadersInit | null {
+  const headers = new Headers(baseCorsHeaders);
+  if (!origin) {
+    return headers;
+  }
+
+  if (allowed.includes(origin)) {
+    headers.set('Access-Control-Allow-Origin', origin);
+    return headers;
+  }
+
+  return null;
+}
+
+function mergeHeaders(...sources: (HeadersInit | null | undefined)[]): Headers {
+  const headers = new Headers();
+  for (const source of sources) {
+    if (!source) continue;
+    const iterable = source instanceof Headers ? source.entries() : Object.entries(source);
+    for (const [key, value] of iterable) {
+      headers.set(key, value);
+    }
+  }
+  return headers;
+}
+
+function baseErrorHeaders(): HeadersInit {
+  return { 'Content-Type': 'application/json; charset=utf-8' };
+}
+
+function baseSuccessHeaders(): HeadersInit {
+  return { 'Content-Type': 'application/json; charset=utf-8' };
+}
+
+function jsonResponse(body: unknown, status = 200, headers?: Headers): Response {
+  const responseHeaders = headers ? new Headers(headers) : new Headers();
+  if (!responseHeaders.has('Content-Type')) {
+    responseHeaders.set('Content-Type', 'application/json; charset=utf-8');
+  }
+  return new Response(JSON.stringify(body), { status, headers: responseHeaders });
+}
+
+type SubmissionPayload = {
+  formType: FormType;
+  data: Record<string, unknown>;
+  turnstileToken?: string;
+  'cf-turnstile-response'?: string;
+};
+
+function extractTurnstileToken(payload: SubmissionPayload): string | undefined {
+  if (payload.turnstileToken && payload.turnstileToken.trim().length > 0) {
+    return payload.turnstileToken;
+  }
+
+  const legacyToken = payload['cf-turnstile-response'];
+  if (legacyToken && legacyToken.trim().length > 0) {
+    return legacyToken;
+  }
+
+  return undefined;
+}
+
+function isSubmissionPayload(value: unknown): value is SubmissionPayload {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<SubmissionPayload>;
+  if (
+    !(
+      candidate.formType === 'family' ||
+      candidate.formType === 'donor' ||
+      candidate.formType === 'collaborator'
+    )
+  ) {
+    return false;
+  }
+
+  if (!candidate.data || typeof candidate.data !== 'object') {
+    return false;
+  }
+
+  const token = extractTurnstileToken(candidate as SubmissionPayload);
+  return typeof token === 'string';
+}
+
+async function verifyTurnstileToken(token: string, secret: string, request: Request) {
+  const remoteIp = request.headers.get('CF-Connecting-IP') ?? undefined;
+  const formData = new URLSearchParams();
+  formData.set('secret', secret);
+  formData.set('response', token);
+  if (remoteIp) {
+    formData.set('remoteip', remoteIp);
+  }
+
+  try {
+    const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      body: formData,
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+
+    if (!response.ok) {
+      return { success: false, error: 'Unable to verify Turnstile token.' };
+    }
+
+    const verification = (await response.json()) as { success: boolean; ['error-codes']?: string[] };
+    if (!verification.success) {
+      const errorCode = verification['error-codes']?.join(', ') ?? 'verification_failed';
+      return { success: false, error: `Turnstile verification failed: ${errorCode}.` };
+    }
+
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: 'Turnstile verification error.' };
+  }
+}
+
+function validateSubmission(formType: FormType, data: Record<string, unknown>): SubmissionResult {
+  switch (formType) {
+    case 'family':
+      return validateFamily(data);
+    case 'donor':
+      return validateDonor(data);
+    case 'collaborator':
+      return validateCollaborator(data);
+    default:
+      return { success: false, error: 'Unsupported form type.' };
+  }
+}
+
+function validateFamily(data: Record<string, unknown>): SubmissionResult {
+  const errors: string[] = [];
+  const name = sanitizeField(data.name, 'Name', { required: true, errors });
+  const email = sanitizeEmail(data.email, errors);
+  const region = sanitizeField(data.region, 'City / Region', { required: true, errors });
+  const interest = sanitizeField(data.interest, 'Interest', { required: false, errors, maxLength: 1000 });
+
+  if (errors.length > 0) {
+    return { success: false, error: errors.join(' ') };
+  }
+
+  const submission: FamilySubmission = {
+    name,
+    email,
+    region,
+    interest: interest || null,
+  };
+
+  return {
+    success: true,
+    table: 'families',
+    parameters: [submission.name, submission.email, submission.region, submission.interest],
+  };
+}
+
+function validateDonor(data: Record<string, unknown>): SubmissionResult {
+  const errors: string[] = [];
+  const name = sanitizeField(data.name, 'Name / Organization', { required: true, errors });
+  const email = sanitizeEmail(data.email, errors);
+  const focus = sanitizeField(data.focus, 'Focus area', { required: false, errors, maxLength: 500 });
+  const message = sanitizeField(data.message, 'Message', { required: false, errors, maxLength: 1500 });
+
+  if (errors.length > 0) {
+    return { success: false, error: errors.join(' ') };
+  }
+
+  const submission: DonorSubmission = {
+    name,
+    email,
+    focus: focus || null,
+    message: message || null,
+  };
+
+  return {
+    success: true,
+    table: 'donors',
+    parameters: [submission.name, submission.email, submission.focus, submission.message],
+  };
+}
+
+function validateCollaborator(data: Record<string, unknown>): SubmissionResult {
+  const errors: string[] = [];
+  const name = sanitizeField(data.name, 'Name / Organization', { required: true, errors });
+  const email = sanitizeEmail(data.email, errors);
+  const expertise = sanitizeField(data.expertise, 'Expertise', { required: false, errors, maxLength: 500 });
+  const idea = sanitizeField(data.idea, 'Idea', { required: false, errors, maxLength: 1500 });
+
+  if (errors.length > 0) {
+    return { success: false, error: errors.join(' ') };
+  }
+
+  const submission: CollaboratorSubmission = {
+    name,
+    email,
+    expertise: expertise || null,
+    idea: idea || null,
+  };
+
+  return {
+    success: true,
+    table: 'collaborators',
+    parameters: [submission.name, submission.email, submission.expertise, submission.idea],
+  };
+}
+
+function sanitizeField(
+  value: unknown,
+  label: string,
+  options: { required: boolean; errors: string[]; maxLength?: number },
+): string {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  if (options.required && raw.length === 0) {
+    options.errors.push(`${label} is required.`);
+  }
+  if (options.maxLength && raw.length > options.maxLength) {
+    options.errors.push(`${label} must be fewer than ${options.maxLength} characters.`);
+  }
+  return raw;
+}
+
+function sanitizeEmail(value: unknown, errors: string[]): string {
+  const email = typeof value === 'string' ? value.trim() : '';
+  if (email.length === 0) {
+    errors.push('Email is required.');
+    return email;
+  }
+  if (!emailRegex.test(email)) {
+    errors.push('Email must be a valid address.');
+  }
+  if (email.length > 320) {
+    errors.push('Email must be fewer than 320 characters.');
+  }
+  return email;
+}
+
+function getInsertStatement(table: string): string {
+  switch (table) {
+    case 'families':
+      return `INSERT INTO families (name, email, region, interest) VALUES (?1, ?2, ?3, ?4);`;
+    case 'donors':
+      return `INSERT INTO donors (name, email, focus, message) VALUES (?1, ?2, ?3, ?4);`;
+    case 'collaborators':
+      return `INSERT INTO collaborators (name, email, expertise, idea) VALUES (?1, ?2, ?3, ?4);`;
+    default:
+      throw new Error('Unknown table.');
+  }
+}

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["es2022"],
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,11 @@
+name = "halo-hub-submissions"
+main = "src/index.ts"
+compatibility_date = "2024-05-20"
+
+[vars]
+ALLOWED_ORIGINS = "https://tymai-dev.github.io,https://halohub.com"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "halo_hub_submissions"
+database_id = "REPLACE_WITH_D1_DATABASE_ID"


### PR DESCRIPTION
## Summary
- add a Cloudflare Worker that validates submissions, verifies Turnstile tokens, and writes pilot form data to D1
- provide SQL migrations, Wrangler configuration, and deployment/runbook details in the README
- enhance the pilot forms with Turnstile widgets, JSON submission to the Worker, and user feedback messaging

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_b_68de8c782e388330b99733a55d8fe713